### PR TITLE
security: Harden CI/CD supply chain and repo config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  CLOG_COMMIT: "9f512365ce09cf1eed592bd49b5d11307639456a"
+
 jobs:
   build-posix:
     strategy:
@@ -13,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install deps (Linux)
         if: runner.os == 'Linux'
@@ -21,8 +24,9 @@ jobs:
 
       - name: Clone and build clog
         run: |
-          git clone --depth 1 https://github.com/matthewdeaves/clog.git "$HOME/clog"
-          mkdir "$HOME/clog/build" && cd "$HOME/clog/build"
+          git clone https://github.com/matthewdeaves/clog.git "$HOME/clog"
+          cd "$HOME/clog" && git checkout ${{ env.CLOG_COMMIT }}
+          mkdir build && cd build
           cmake .. && make
 
       - name: Build peertalk
@@ -41,7 +45,7 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install cppcheck
         run: sudo apt-get update && sudo apt-get install -y cppcheck
@@ -60,14 +64,15 @@ jobs:
   build-68k-mactcp:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthewdeaves/retro68:latest
+      image: ghcr.io/matthewdeaves/retro68@sha256:2433db2d7e8da9256c443b6193bf5dbe81b20d5f3b42a916eee80b7a711d5c9c
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Clone and build clog for 68k
         run: |
-          git clone --depth 1 https://github.com/matthewdeaves/clog.git /tmp/clog
-          mkdir /tmp/clog/build && cd /tmp/clog/build
+          git clone https://github.com/matthewdeaves/clog.git /tmp/clog
+          cd /tmp/clog && git checkout ${{ env.CLOG_COMMIT }}
+          mkdir build && cd build
           cmake .. -DCMAKE_TOOLCHAIN_FILE=/Retro68-build/toolchain/m68k-apple-macos/cmake/retro68.toolchain.cmake
           make
 
@@ -84,14 +89,15 @@ jobs:
   build-ppc-mactcp:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthewdeaves/retro68:latest
+      image: ghcr.io/matthewdeaves/retro68@sha256:2433db2d7e8da9256c443b6193bf5dbe81b20d5f3b42a916eee80b7a711d5c9c
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Clone and build clog for PPC
         run: |
-          git clone --depth 1 https://github.com/matthewdeaves/clog.git /tmp/clog
-          mkdir /tmp/clog/build && cd /tmp/clog/build
+          git clone https://github.com/matthewdeaves/clog.git /tmp/clog
+          cd /tmp/clog && git checkout ${{ env.CLOG_COMMIT }}
+          mkdir build && cd build
           cmake .. -DCMAKE_TOOLCHAIN_FILE=/Retro68-build/toolchain/powerpc-apple-macos/cmake/retroppc.toolchain.cmake
           make
 
@@ -108,14 +114,15 @@ jobs:
   build-ppc-ot:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthewdeaves/retro68:latest
+      image: ghcr.io/matthewdeaves/retro68@sha256:2433db2d7e8da9256c443b6193bf5dbe81b20d5f3b42a916eee80b7a711d5c9c
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Clone and build clog for PPC
         run: |
-          git clone --depth 1 https://github.com/matthewdeaves/clog.git /tmp/clog
-          mkdir /tmp/clog/build && cd /tmp/clog/build
+          git clone https://github.com/matthewdeaves/clog.git /tmp/clog
+          cd /tmp/clog && git checkout ${{ env.CLOG_COMMIT }}
+          mkdir build && cd build
           cmake .. -DCMAKE_TOOLCHAIN_FILE=/Retro68-build/toolchain/powerpc-apple-macos/cmake/retroppc.toolchain.cmake
           make
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
   build-68k-mactcp:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthewdeaves/retro68@sha256:2433db2d7e8da9256c443b6193bf5dbe81b20d5f3b42a916eee80b7a711d5c9c
+      image: ghcr.io/matthewdeaves/retro68@sha256:11bc3005f2cd602ad311ab98d91e3999239648d89b1f6413810eafe93a2a145c
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -89,7 +89,7 @@ jobs:
   build-ppc-mactcp:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthewdeaves/retro68@sha256:2433db2d7e8da9256c443b6193bf5dbe81b20d5f3b42a916eee80b7a711d5c9c
+      image: ghcr.io/matthewdeaves/retro68@sha256:11bc3005f2cd602ad311ab98d91e3999239648d89b1f6413810eafe93a2a145c
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -114,7 +114,7 @@ jobs:
   build-ppc-ot:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/matthewdeaves/retro68@sha256:2433db2d7e8da9256c443b6193bf5dbe81b20d5f3b42a916eee80b7a711d5c9c
+      image: ghcr.io/matthewdeaves/retro68@sha256:11bc3005f2cd602ad311ab98d91e3999239648d89b1f6413810eafe93a2a145c
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,24 @@ on:
   push:
     tags: ['v*']
 
+env:
+  CLOG_COMMIT: "9f512365ce09cf1eed592bd49b5d11307639456a"
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Clone and build clog
         run: |
           git clone https://github.com/matthewdeaves/clog.git "$HOME/clog"
-          mkdir "$HOME/clog/build" && cd "$HOME/clog/build" && cmake .. && make
+          cd "$HOME/clog" && git checkout ${{ env.CLOG_COMMIT }}
+          mkdir build && cd build && cmake .. && make
 
       - name: Build peertalk
         run: mkdir build && cd build && cmake .. -DCLOG_DIR="$HOME/clog" && make
@@ -66,7 +70,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           body: ${{ steps.notes.outputs.notes }}
           files: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,9 @@
 # Security Policy
 
-## Supported Versions
-
-| Version | Supported          |
-|---------|--------------------|
-| latest  | :white_check_mark: |
-
 ## Reporting a Vulnerability
-
-If you discover a security vulnerability in peertalk, please report it responsibly.
 
 **Do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, please use GitHub's private vulnerability reporting feature:
+Please report vulnerabilities via GitHub's private advisory feature:
 
-1. Go to https://github.com/matthewdeaves/peertalk/security/advisories
-2. Click "New draft security advisory"
-3. Fill in the details of the vulnerability
-
-You can expect an initial response within 72 hours.
+https://github.com/matthewdeaves/peertalk/security/advisories

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in peertalk, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use GitHub's private vulnerability reporting feature:
+
+1. Go to https://github.com/matthewdeaves/peertalk/security/advisories
+2. Click "New draft security advisory"
+3. Fill in the details of the vulnerability
+
+You can expect an initial response within 72 hours.


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to immutable SHA hashes (actions/checkout, softprops/action-gh-release)
- Pin clog dependency clone to specific commit SHA via `CLOG_COMMIT` env var
- Pin retro68 container image to digest instead of `:latest` tag
- Add Dependabot config for automatic GitHub Actions update PRs
- Add SECURITY.md with vulnerability reporting policy
- Branch protection updated: 1 required reviewer, enforce admins, dismiss stale reviews

## Test plan
- [ ] CI passes on this PR (validates pinned SHAs resolve correctly)
- [ ] Container jobs pull the correct image by digest
- [ ] clog checkout succeeds at pinned commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)