### PR TITLE
feat: Add PT_LocalAddress, PT_SendUDPBroadcast APIs

### DIFF
--- a/.claude/mcp-servers/classic-mac-hardware/server.py
+++ b/.claude/mcp-servers/classic-mac-hardware/server.py
@@ -48,6 +48,7 @@ class ClassicMacHardwareServer:
         self._config_mtime = 0
         self._first_load = True
         self._last_ftp_time = 0  # For rate limiting
+        self._exec_lock = asyncio.Lock()  # Serialize LaunchAPPL calls
         self._reload_if_changed()
         self._first_load = False
         self.server = Server("classic-mac-hardware")
@@ -366,7 +367,7 @@ class ClassicMacHardwareServer:
             elif name == "download_file":
                 return self._tool_download_file(arguments)
             elif name == "execute_binary":
-                return self._tool_execute_binary(arguments)
+                return await self._tool_execute_binary(arguments)
             else:
                 raise ValueError(f"Unknown tool: {name}")
         except Exception as e:
@@ -618,10 +619,8 @@ class ClassicMacHardwareServer:
                  f"  Size:   {file_size:,} bytes"
         )]
 
-    def _tool_execute_binary(self, args: dict) -> list[TextContent]:
-        """Execute binary via LaunchAPPL."""
-        import subprocess
-
+    async def _tool_execute_binary(self, args: dict) -> list[TextContent]:
+        """Execute binary via LaunchAPPL (serialized, non-blocking)."""
         machine_id = args["machine"]
         binary_path = args["binary_path"]
 
@@ -653,34 +652,63 @@ class ClassicMacHardwareServer:
         if not machine_ip:
             return [TextContent(type="text", text=f"No host configured for {machine['name']}. Add 'launchappl.host' or 'ftp.host' to machines.json")]
 
-        binary_path = str(Path(binary_path).resolve())
+        binary_path_resolved = str(Path(binary_path).resolve())
+        binary_size = Path(binary_path_resolved).stat().st_size
+        binary_name = Path(binary_path_resolved).name
 
-        try:
-            cmd = [launchappl, "-e", "tcp", "--tcp-address", machine_ip, binary_path]
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                    text=True, cwd="/tmp")
+        # Serialize all LaunchAPPL calls — one at a time to avoid
+        # network contention and port conflicts on the Mac side.
+        async with self._exec_lock:
             try:
-                stdout, stderr = proc.communicate(timeout=120)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-                return [TextContent(
-                    type="text",
-                    text=f"Timed out after 120s. Binary may still be running on {machine['name']}.\n"
-                         f"Download logs via FTP when the test completes:\n"
-                         f"  download_file(machine=\"{machine_id}\", remote_path=\"PT_Log\")"
-                )]
+                cmd = [launchappl, "-e", "tcp", "--tcp-address", machine_ip,
+                       binary_path_resolved]
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd="/tmp"
+                )
 
-            if proc.returncode == 0:
-                return [TextContent(type="text", text=f"Executed on {machine['name']}:\n\n{stdout}")]
-            else:
-                return [TextContent(
-                    type="text",
-                    text=f"Execution failed:\n\n{stderr}\n\n"
-                         f"Ensure LaunchAPPLServer is running on {machine['name']}"
-                )]
-        except Exception as e:
-            return [TextContent(type="text", text=f"Error: {e}")]
+                timeout = 120
+                try:
+                    stdout, stderr = await asyncio.wait_for(
+                        proc.communicate(), timeout=timeout
+                    )
+                    stdout_text = stdout.decode() if stdout else ""
+                    stderr_text = stderr.decode() if stderr else ""
+                except asyncio.TimeoutError:
+                    # Kill so the lock is released cleanly
+                    proc.kill()
+                    await proc.wait()
+                    return [TextContent(
+                        type="text",
+                        text=f"Timed out after {timeout}s on {machine['name']}.\n"
+                             f"Binary: {binary_name} ({binary_size:,} bytes)\n\n"
+                             f"The app may still be running. Download logs via FTP:\n"
+                             f"  download_file(machine=\"{machine_id}\", remote_path=\"PT_Log\")"
+                    )]
+
+                # Brief pause after execution for Mac to clean up
+                await asyncio.sleep(2)
+
+                if proc.returncode == 0:
+                    output = stdout_text.strip()
+                    return [TextContent(
+                        type="text",
+                        text=f"Executed on {machine['name']} (exit 0):\n"
+                             f"  Binary: {binary_name} ({binary_size:,} bytes)\n"
+                             + (f"\n{output}\n" if output else "\n  (no stdout — check PT_Log)\n")
+                    )]
+                else:
+                    return [TextContent(
+                        type="text",
+                        text=f"FAILED on {machine['name']} (exit {proc.returncode}):\n"
+                             f"  Binary: {binary_name} ({binary_size:,} bytes)\n\n"
+                             f"{stderr_text}\n\n"
+                             f"Ensure LaunchAPPLServer is running on {machine['name']}"
+                    )]
+            except Exception as e:
+                return [TextContent(type="text", text=f"Error: {e}")]
 
 
 async def main():

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@
 ```mermaid
 graph TB
     Dev["App Developer<br/><i>Games and chat apps</i>"]
-    SDK["<b>PeerTalk SDK</b><br/>C89 LAN peer-to-peer networking<br/>22 functions, 4,410 LOC"]
+    SDK["<b>PeerTalk SDK</b><br/>C89 LAN peer-to-peer networking<br/>24 functions, 4,136 LOC"]
     LAN["LAN<br/><i>Ethernet</i>"]
     Clog["clog<br/><i>Logging library</i>"]
 
@@ -27,9 +27,9 @@ graph TB
 graph TB
     Dev["App Developer"]
 
-    subgraph SDK ["PeerTalk SDK — 4,410 LOC"]
-        API["<b>peertalk.h</b><br/>22 functions<br/><i>C89, 165 LOC</i>"]
-        Core["<b>Core Layer</b><br/>Discovery, messaging, memory<br/><i>C89, 1,674 LOC</i>"]
+    subgraph SDK ["PeerTalk SDK — 4,136 LOC"]
+        API["<b>peertalk.h</b><br/>24 functions<br/><i>C89, 168 LOC</i>"]
+        Core["<b>Core Layer</b><br/>Discovery, messaging, memory<br/><i>C89, 1,692 LOC</i>"]
         POSIX["<b>POSIX Backend</b><br/>BSD sockets + select()<br/><i>C89, 548 LOC</i>"]
         MacTCP["<b>MacTCP Backend</b><br/>Async PBs + ASR flags<br/><i>C89, 995 LOC</i>"]
         OT["<b>OT Backend</b><br/>Endpoints + notifiers<br/><i>C89, 1,028 LOC</i>"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ These 10 principles govern ALL implementation decisions. Full text: `.specify/me
 ## Project Structure
 
 ```
-include/peertalk.h          # Single public header (C89, 22 functions)
+include/peertalk.h          # Single public header (C89, 24 functions)
 src/core/                   # Platform-independent core
 src/platform/posix/         # BSD sockets + select()
 src/platform/mactcp/        # MacTCP async parameter blocks (68k)

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A C networking SDK for LAN peer-to-peer communication between modern POSIX syste
 
 ## Features
 
-- **22-function C89 API** with a single public header (`peertalk.h`)
+- **24-function C89 API** with a single public header (`peertalk.h`)
 - **3 platform backends**: POSIX (BSD sockets), MacTCP (68k/PPC), Open Transport (PPC)
 - **Zero allocation after init** — all buffers pre-allocated in a single block
 - **Automatic peer discovery** via UDP broadcast
 - **Reliable (TCP) and fast (UDP)** message transports
-- **~4,400 lines of SDK code** across all platforms
+- **~4,100 lines of SDK code** across all platforms
 
 ## Supported Platforms
 
@@ -43,7 +43,7 @@ while (running) {
 PT_Shutdown(ctx);
 ```
 
-See [API Contract](specs/001-peertalk-sdk/contracts/peertalk-api.md) for the full 22-function reference.
+See [API Contract](specs/001-peertalk-sdk/contracts/peertalk-api.md) for the full 24-function reference.
 
 ## Prerequisites
 
@@ -79,7 +79,7 @@ target_link_libraries(myapp PRIVATE peertalk)
 ## Project Structure
 
 ```
-include/peertalk.h          # Single public header (C89, 22 functions)
+include/peertalk.h          # Single public header (C89, 24 functions)
 src/core/                   # Platform-independent core
 src/platform/posix/         # BSD sockets + select()
 src/platform/mactcp/        # MacTCP async parameter blocks
@@ -96,7 +96,7 @@ tests/                      # 7 test apps
 | test_fast | Bomberman (UDP) | High-frequency positional updates at 60 Hz |
 | test_chat | Chat (TCP) | Variable-length bidirectional messages |
 | test_multi | Multi-peer | N-way discovery, connect all, broadcast to all, verify receipt |
-| test_init_only | Init/shutdown | Memory allocation, error path validation (5 checks) |
+| test_init_only | Init/shutdown | Memory allocation, error path validation (10 checks) |
 | test_clog_minimal | Logging | clog library verification |
 
 ## Hardware Verification

--- a/include/peertalk.h
+++ b/include/peertalk.h
@@ -155,7 +155,10 @@ PT_Status PT_SetName(PT_Context *ctx, const char *name);
 int              PT_GetPeerCount(const PT_Context *ctx);
 PT_Peer         *PT_GetPeer(PT_Context *ctx, int index);
 const char      *PT_PeerName(const PT_Peer *peer);
-const char      *PT_PeerAddress(const PT_Peer *peer);
+const char      *PT_PeerAddress(const PT_Peer *peer);   /* static buf, valid until next call */
+const char      *PT_LocalAddress(const PT_Context *ctx); /* static buf, valid until next call */
+PT_Status        PT_SendUDPBroadcast(PT_Context *ctx, unsigned short port,
+                                     const void *data, size_t len);
 PT_PeerState     PT_GetPeerState(const PT_Peer *peer);
 
 #ifdef __cplusplus

--- a/src/core/pt_core.c
+++ b/src/core/pt_core.c
@@ -650,6 +650,24 @@ const char *PT_PeerAddress(const PT_Peer *pub_peer)
     return peer->addr_str;
 }
 
+const char *PT_LocalAddress(const PT_Context *pub_ctx)
+{
+    static char local_addr_str[16];
+    const PT_Context_Internal *ctx = (const PT_Context_Internal *)pub_ctx;
+    if (!ctx || ctx->local_ip == 0) return "";
+    pt_format_ip(ctx->local_ip, local_addr_str);
+    return local_addr_str;
+}
+
+PT_Status PT_SendUDPBroadcast(PT_Context *pub_ctx, unsigned short port,
+                              const void *data, size_t len)
+{
+    PT_Context_Internal *ctx = (PT_Context_Internal *)pub_ctx;
+    if (!ctx) return PT_ERR_INVALID_ARG;
+    if (!data && len > 0) return PT_ERR_INVALID_ARG;
+    return ctx->platform_ops->udp_broadcast(ctx, port, data, len);
+}
+
 PT_PeerState PT_GetPeerState(const PT_Peer *pub_peer)
 {
     const PT_Peer_Internal *peer = (const PT_Peer_Internal *)pub_peer;

--- a/tests/test_init_only.c
+++ b/tests/test_init_only.c
@@ -158,6 +158,60 @@ int main(void)
             CLOG_INFO("PT_Broadcast(NULL ctx) = %d: FAIL", (int)st);
         }
 
+        /* PT_LocalAddress after init should return dotted-quad */
+        err_total++;
+        {
+            const char *addr = PT_LocalAddress(ctx);
+            if (addr && addr[0] != '\0') {
+                CLOG_INFO("PT_LocalAddress = \"%s\": OK", addr);
+                err_pass++;
+            } else {
+                CLOG_INFO("PT_LocalAddress = empty: FAIL");
+            }
+        }
+
+        /* PT_LocalAddress(NULL) should return empty */
+        err_total++;
+        {
+            const char *addr = PT_LocalAddress(NULL);
+            if (addr && addr[0] == '\0') {
+                CLOG_INFO("PT_LocalAddress(NULL) = empty: OK");
+                err_pass++;
+            } else {
+                CLOG_INFO("PT_LocalAddress(NULL) = \"%s\": FAIL", addr ? addr : "(null)");
+            }
+        }
+
+        /* PT_SendUDPBroadcast with NULL ctx */
+        err_total++;
+        st = PT_SendUDPBroadcast(NULL, 7355, "test", 4);
+        if (st == PT_ERR_INVALID_ARG) {
+            CLOG_INFO("PT_SendUDPBroadcast(NULL ctx) = INVALID_ARG: OK");
+            err_pass++;
+        } else {
+            CLOG_INFO("PT_SendUDPBroadcast(NULL ctx) = %d: FAIL", (int)st);
+        }
+
+        /* PT_SendUDPBroadcast with NULL data and len > 0 */
+        err_total++;
+        st = PT_SendUDPBroadcast(ctx, 7355, NULL, 10);
+        if (st == PT_ERR_INVALID_ARG) {
+            CLOG_INFO("PT_SendUDPBroadcast(NULL data, len>0) = INVALID_ARG: OK");
+            err_pass++;
+        } else {
+            CLOG_INFO("PT_SendUDPBroadcast(NULL data, len>0) = %d: FAIL", (int)st);
+        }
+
+        /* PT_SendUDPBroadcast with valid data (broadcasts to nobody) */
+        err_total++;
+        st = PT_SendUDPBroadcast(ctx, 7355, "hello", 5);
+        if (st == PT_OK) {
+            CLOG_INFO("PT_SendUDPBroadcast(valid) = OK: OK");
+            err_pass++;
+        } else {
+            CLOG_INFO("PT_SendUDPBroadcast(valid) = %d: FAIL", (int)st);
+        }
+
         CLOG_INFO("Error paths: %d/%d passed", err_pass, err_total);
         if (err_pass != err_total) {
             CLOG_INFO("=== test_init_only FAILED (error paths) ===");


### PR DESCRIPTION
## Summary
- Add `PT_LocalAddress(ctx)` returning local IP as dotted-quad string
- Add `PT_SendUDPBroadcast(ctx, port, data, len)` for explicit UDP broadcast
- Expand test_init_only from 5 to 10 error-path checks covering both new APIs
- Make MCP `execute_binary` async with serialization lock (non-blocking LaunchAPPL)
- Update docs to reflect 24-function API and current line counts

## Hardware verified
All 3 Classic Macs pass test_init_only with 10/10 error paths:
- Mac SE (68000, MacTCP, IP 10.188.1.55) — PASS
- Performa 6200 (PPC 603, MacTCP, IP 10.188.1.213) — PASS
- Performa 6400 (PPC 603e, Open Transport, IP 10.188.1.102) — PASS

## Test plan
- [ ] CI passes (POSIX build + tests)
- [ ] Cross-compilation succeeds (68k MacTCP, PPC OT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)